### PR TITLE
Add refund to the list of valid PaymentTransactionCodeTypes

### DIFF
--- a/PayPalMerchantSDK/PayPalAPIInterfaceService/PayPalPayPalAPIInterfaceServiceModel.cs
+++ b/PayPalMerchantSDK/PayPalAPIInterfaceService/PayPalPayPalAPIInterfaceServiceModel.cs
@@ -1270,7 +1270,8 @@ namespace PayPal.PayPalAPIInterfaceService.Model
 		[Description("express-checkout")]EXPRESSCHECKOUT,	
 		[Description("pro-hosted")]PROHOSTED,	
 		[Description("pro-api")]PROAPI,	
-		[Description("credit")]CREDIT	
+		[Description("credit")]CREDIT,
+		[Description("refund")]REFUND
 	}
 
 


### PR DESCRIPTION
This is to address the bug noted in this issue: https://github.com/paypal/merchant-sdk-dotnet/issues/20.  While it is understandable that we need to migrate to the REST SDK, some people are still using the legacy version.